### PR TITLE
Fix issue #2: Config files for default settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,118 @@
+# Configuration System
+
+Clive uses a configuration system to store and manage settings. The configuration is stored in a JSON file at `~/.clive/settings.json`.
+
+## Configuration Structure
+
+The configuration file has the following structure:
+
+```json
+{
+  "vision_llm": {
+    "api_key": "your_api_key",
+    "api_base": "https://api.example.com",
+    "model_id": "provider/model-name"
+  },
+  "llm": {
+    "api_key": "your_api_key",
+    "api_base": "https://api.example.com",
+    "model_id": "provider/model-name"
+  },
+  "embedding": {
+    "model_id": "model-name"
+  }
+}
+```
+
+### Vision LLM
+
+The Vision LLM is used for interpreting screenshots and other visual content.
+
+- `api_key`: The API key for the LLM
+- `api_base`: The API base URL
+- `model_id`: The ID for the model in [LiteLLM format](https://docs.litellm.ai/docs/#basic-usage). `provider/model-name`
+
+### LLM
+
+The LLM is used for other tasks such as text processing and generation.
+
+- `api_key`: The API key for the LLM
+- `api_base`: The API base URL
+- `model_id`: The ID for the model in [LiteLLM format](https://docs.litellm.ai/docs/#basic-usage). `provider/model-name`
+
+### Embedding Model
+
+The embedding model is used for generating vector embeddings of text.
+
+- `model_id`: The ID for the model in Ollama's format. `model-name`
+
+## Managing Configuration
+
+### Command Line Interface
+
+You can manage the configuration using the `config.py` script in the `scripts` directory:
+
+```bash
+# Show the current configuration
+python scripts/config.py show
+
+# Set the vision LLM configuration
+python scripts/config.py set_vision_llm --api_key=your_api_key --api_base=https://api.example.com --model_id=provider/model-name
+
+# Set the LLM configuration
+python scripts/config.py set_llm --api_key=your_api_key --api_base=https://api.example.com --model_id=provider/model-name
+
+# Set the embedding model configuration
+python scripts/config.py set_embedding --model_id=model-name
+
+# Reset the configuration to default values
+python scripts/config.py reset
+```
+
+### Programmatic Access
+
+You can also manage the configuration programmatically:
+
+```python
+from src.utils.config import get_settings, save_settings
+
+# Get the current settings
+settings = get_settings()
+
+# Update the settings
+settings.llm.model_id = "ollama/llama3:8b"
+settings.vision_llm.model_id = "ollama/llama3:8b"
+settings.embedding.model_id = "nomic-embed-text:latest"
+
+# Save the settings
+save_settings(settings)
+```
+
+## Environment Variables
+
+The configuration system also respects environment variables. If an environment variable is set, it takes precedence over the value in the configuration file.
+
+The following environment variables are supported:
+
+- `LLM_API_KEY`: The API key for the LLM
+- `LLM_BASE_URL`: The API base URL for the LLM
+- `LLM_MODEL`: The model ID for the LLM
+- `VISION_LLM_API_KEY`: The API key for the Vision LLM
+- `VISION_LLM_BASE_URL`: The API base URL for the Vision LLM
+- `VISION_LLM_MODEL`: The model ID for the Vision LLM
+- `EMBEDDING_MODEL`: The model ID for the embedding model
+
+## Default Values
+
+If the configuration file doesn't exist, the following default values are used:
+
+- Vision LLM:
+  - `api_key`: "ollama"
+  - `api_base`: "http://localhost:11434"
+  - `model_id`: "ollama/gemma3:12b"
+- LLM:
+  - `api_key`: "ollama"
+  - `api_base`: "http://localhost:11434"
+  - `model_id`: "ollama/gemma3:12b"
+- Embedding:
+  - `model_id`: "nomic-embed-text"

--- a/examples/config_example.py
+++ b/examples/config_example.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Example script demonstrating how to use the configuration system.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Add the workspace directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.utils.config import (
+    EmbeddingConfig,
+    LLMConfig,
+    Settings,
+    get_settings,
+    save_settings,
+)
+
+
+def main():
+    """Run the example."""
+    # Get the current settings
+    settings = get_settings()
+    print("Current settings:")
+    print(json.dumps(settings.model_dump(), indent=2))
+
+    # Update the settings
+    settings.llm.model_id = "ollama/llama3:8b"
+    settings.vision_llm.model_id = "ollama/llama3:8b"
+    settings.embedding.model_id = "nomic-embed-text:latest"
+
+    # Save the settings
+    save_settings(settings)
+    print("\nSettings updated.")
+
+    # Reload the settings
+    settings = get_settings()
+    print("\nUpdated settings:")
+    print(json.dumps(settings.model_dump(), indent=2))
+
+    # Reset to default settings
+    default_settings = Settings(
+        vision_llm=LLMConfig(
+            api_key="ollama",
+            api_base="http://localhost:11434",
+            model_id="ollama/gemma3:12b"
+        ),
+        llm=LLMConfig(
+            api_key="ollama",
+            api_base="http://localhost:11434",
+            model_id="ollama/gemma3:12b"
+        ),
+        embedding=EmbeddingConfig(
+            model_id="nomic-embed-text"
+        )
+    )
+    save_settings(default_settings)
+    print("\nSettings reset to default values.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     "fire>=0.7.0",
     "httpx>=0.28.1",
     "litellm>=1.65.4.post1",
+    "pydantic>=2.11.3",
+    "pytest>=8.3.5",
     "python-dotenv>=1.1.0",
     "smolagents>=1.13.0",
 ]

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+Configuration management script for Clive.
+
+This script provides a command-line interface for managing the Clive configuration.
+"""
+
+import os
+import sys
+
+# Add the workspace directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.utils.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -1,0 +1,117 @@
+import json
+from typing import Optional
+
+import fire
+
+from src.utils.config import (
+    EmbeddingConfig,
+    LLMConfig,
+    Settings,
+    get_settings,
+    save_settings,
+)
+
+
+class ConfigCLI:
+    """Command-line interface for managing configuration."""
+
+    def show(self) -> None:
+        """Show the current configuration."""
+        settings = get_settings()
+        print(json.dumps(settings.model_dump(), indent=2))
+
+    def set_vision_llm(
+        self,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        model_id: Optional[str] = None,
+    ) -> None:
+        """Set the vision LLM configuration.
+
+        Args:
+            api_key: The API key for the LLM
+            api_base: The API base URL
+            model_id: The ID for the model in LiteLLM format. provider/model-name
+        """
+        settings = get_settings()
+
+        if api_key is not None:
+            settings.vision_llm.api_key = api_key
+
+        if api_base is not None:
+            settings.vision_llm.api_base = api_base
+
+        if model_id is not None:
+            settings.vision_llm.model_id = model_id
+
+        save_settings(settings)
+        print("Vision LLM configuration updated.")
+
+    def set_llm(
+        self,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        model_id: Optional[str] = None,
+    ) -> None:
+        """Set the LLM configuration.
+
+        Args:
+            api_key: The API key for the LLM
+            api_base: The API base URL
+            model_id: The ID for the model in LiteLLM format. provider/model-name
+        """
+        settings = get_settings()
+
+        if api_key is not None:
+            settings.llm.api_key = api_key
+
+        if api_base is not None:
+            settings.llm.api_base = api_base
+
+        if model_id is not None:
+            settings.llm.model_id = model_id
+
+        save_settings(settings)
+        print("LLM configuration updated.")
+
+    def set_embedding(
+        self,
+        model_id: Optional[str] = None,
+    ) -> None:
+        """Set the embedding model configuration.
+
+        Args:
+            model_id: The ID for the model in Ollama's format. model-name
+        """
+        settings = get_settings()
+
+        if model_id is not None:
+            settings.embedding.model_id = model_id
+
+        save_settings(settings)
+        print("Embedding model configuration updated.")
+
+    def reset(self) -> None:
+        """Reset the configuration to default values."""
+        settings = Settings(
+            vision_llm=LLMConfig(
+                api_key="ollama",
+                api_base="http://localhost:11434",
+                model_id="ollama/gemma3:12b"
+            ),
+            llm=LLMConfig(
+                api_key="ollama",
+                api_base="http://localhost:11434",
+                model_id="ollama/gemma3:12b"
+            ),
+            embedding=EmbeddingConfig(
+                model_id="nomic-embed-text"
+            )
+        )
+        save_settings(settings)
+        print("Configuration reset to default values.")
+
+
+def main() -> None:
+    """Run the configuration CLI."""
+    fire.Fire(ConfigCLI)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,0 +1,96 @@
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class LLMConfig(BaseModel):
+    """Configuration for an LLM model."""
+    api_key: str = Field(description="The API key for the LLM")
+    api_base: str = Field(description="The API base URL")
+    model_id: str = Field(description="The ID for the model in LiteLLM format. provider/model-name")
+
+
+class EmbeddingConfig(BaseModel):
+    """Configuration for an embedding model."""
+    model_id: str = Field(description="The ID for the model in Ollama's format. model-name")
+
+
+class Settings(BaseModel):
+    """Global settings for the application."""
+    vision_llm: LLMConfig = Field(description="Vision LLM used for interpreting screenshots")
+    llm: LLMConfig = Field(description="LLM used for other tasks")
+    embedding: EmbeddingConfig = Field(description="Embedding model configuration")
+
+
+def get_config_dir() -> Path:
+    """Get the configuration directory path."""
+    config_dir = Path.home() / ".clive"
+    config_dir.mkdir(exist_ok=True)
+    return config_dir
+
+
+def get_config_path() -> Path:
+    """Get the configuration file path."""
+    return get_config_dir() / "settings.json"
+
+
+def load_settings() -> Settings:
+    """Load settings from the configuration file."""
+    config_path = get_config_path()
+
+    # If the config file doesn't exist, create it with default settings
+    if not config_path.exists():
+        default_settings = Settings(
+            vision_llm=LLMConfig(
+                api_key="ollama",
+                api_base="http://localhost:11434",
+                model_id="ollama/gemma3:12b"
+            ),
+            llm=LLMConfig(
+                api_key="ollama",
+                api_base="http://localhost:11434",
+                model_id="ollama/gemma3:12b"
+            ),
+            embedding=EmbeddingConfig(
+                model_id="nomic-embed-text"
+            )
+        )
+        save_settings(default_settings)
+        return default_settings
+
+    # Load settings from the config file
+    with open(config_path, "r") as f:
+        config_data = json.load(f)
+
+    return Settings.model_validate(config_data)
+
+
+def save_settings(settings: Settings) -> None:
+    """Save settings to the configuration file."""
+    config_path = get_config_path()
+
+    with open(config_path, "w") as f:
+        json.dump(settings.model_dump(), f, indent=2)
+
+
+# Global settings instance
+_settings: Optional[Settings] = None
+
+
+def get_settings() -> Settings:
+    """Get the global settings instance."""
+    global _settings
+    if _settings is None:
+        _settings = load_settings()
+    return _settings
+
+
+def reload_settings() -> Settings:
+    """Reload settings from the configuration file."""
+    global _settings
+    # Force a reload by calling load_settings directly
+    _settings = None
+    return get_settings()

--- a/src/utils/env.py
+++ b/src/utils/env.py
@@ -2,25 +2,31 @@ import os
 
 from dotenv import load_dotenv
 
+from src.utils.config import get_settings
+
 load_dotenv()
 
+# Load settings from config file
+settings = get_settings()
+
 # LLM_BASE_URL is the base URL for the LLM
-# If none is specified assume local Ollama
-LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:11434")
+# Environment variables take precedence over config file
+LLM_BASE_URL = os.getenv("LLM_BASE_URL", settings.llm.api_base)
 
 # LLM_API_KEY is the API key for the LLM
-LLM_API_KEY = os.getenv("LLM_API_KEY", "ollama")
+LLM_API_KEY = os.getenv("LLM_API_KEY", settings.llm.api_key)
 
 # LLM_MODEL is the model to use for the LLM
-# if none specified assume Gemma 3 12b
-LLM_MODEL = os.getenv("LLM_MODEL", "ollama/gemma3:12b")
+LLM_MODEL = os.getenv("LLM_MODEL", settings.llm.model_id)
 
 # VISION_LLM_BASE_URL is the base URL for the Vision LLM
-VISION_LLM_BASE_URL = os.getenv(
-    "VISION_LLM_BASE_URL", "http://localhost:11434")
+VISION_LLM_BASE_URL = os.getenv("VISION_LLM_BASE_URL", settings.vision_llm.api_base)
 
 # VISION_LLM_API_KEY is the API key for the Vision LLM
-VISION_LLM_API_KEY = os.getenv("VISION_LLM_API_KEY", "ollama")
+VISION_LLM_API_KEY = os.getenv("VISION_LLM_API_KEY", settings.vision_llm.api_key)
 
 # VISION_LLM_MODEL is the model to use for the Vision LLM
-VISION_LLM_MODEL = os.getenv("VISION_LLM_MODEL", "ollama/gemma3:12b")
+VISION_LLM_MODEL = os.getenv("VISION_LLM_MODEL", settings.vision_llm.model_id)
+
+# EMBEDDING_MODEL is the model to use for embeddings
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", settings.embedding.model_id)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,217 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from src.utils.config import (
+    EmbeddingConfig,
+    LLMConfig,
+    Settings,
+    get_config_dir,
+    get_config_path,
+    get_settings,
+    load_settings,
+    reload_settings,
+    save_settings,
+)
+
+
+def test_config_models():
+    """Test that the configuration models work correctly."""
+    # Test LLMConfig
+    llm_config = LLMConfig(
+        api_key="test_key",
+        api_base="http://test.com",
+        model_id="test/model"
+    )
+    assert llm_config.api_key == "test_key"
+    assert llm_config.api_base == "http://test.com"
+    assert llm_config.model_id == "test/model"
+
+    # Test EmbeddingConfig
+    embedding_config = EmbeddingConfig(
+        model_id="test-model"
+    )
+    assert embedding_config.model_id == "test-model"
+
+    # Test Settings
+    settings = Settings(
+        vision_llm=llm_config,
+        llm=llm_config,
+        embedding=embedding_config
+    )
+    assert settings.vision_llm == llm_config
+    assert settings.llm == llm_config
+    assert settings.embedding == embedding_config
+
+
+@mock.patch("src.utils.config.get_config_path")
+def test_load_and_save_settings(mock_get_config_path):
+    """Test loading and saving settings."""
+    # Create a temporary file for testing
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_path = Path(temp_file.name)
+
+    try:
+        # Mock the config path to use our temporary file
+        mock_get_config_path.return_value = temp_path
+
+        # Test saving settings
+        settings = Settings(
+            vision_llm=LLMConfig(
+                api_key="test_key",
+                api_base="http://test.com",
+                model_id="test/model"
+            ),
+            llm=LLMConfig(
+                api_key="test_key2",
+                api_base="http://test2.com",
+                model_id="test/model2"
+            ),
+            embedding=EmbeddingConfig(
+                model_id="test-model"
+            )
+        )
+        save_settings(settings)
+
+        # Verify the file was created with the correct content
+        assert temp_path.exists()
+        with open(temp_path, "r") as f:
+            saved_data = json.load(f)
+
+        assert saved_data["vision_llm"]["api_key"] == "test_key"
+        assert saved_data["llm"]["api_base"] == "http://test2.com"
+        assert saved_data["embedding"]["model_id"] == "test-model"
+
+        # Test loading settings
+        loaded_settings = load_settings()
+        assert loaded_settings.vision_llm.api_key == "test_key"
+        assert loaded_settings.llm.api_base == "http://test2.com"
+        assert loaded_settings.embedding.model_id == "test-model"
+
+    finally:
+        # Clean up the temporary file
+        if temp_path.exists():
+            os.unlink(temp_path)
+
+
+@mock.patch("src.utils.config.get_config_path")
+def test_default_settings_creation(mock_get_config_path):
+    """Test that default settings are created if the config file doesn't exist."""
+    # Create a temporary path that doesn't exist
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir) / "settings.json"
+
+        # Mock the config path to use our temporary file
+        mock_get_config_path.return_value = temp_path
+
+        # Load settings (should create default settings)
+        settings = load_settings()
+
+        # Verify default values
+        assert settings.vision_llm.api_key == "ollama"
+        assert settings.vision_llm.api_base == "http://localhost:11434"
+        assert settings.vision_llm.model_id == "ollama/gemma3:12b"
+        assert settings.llm.api_key == "ollama"
+        assert settings.llm.api_base == "http://localhost:11434"
+        assert settings.llm.model_id == "ollama/gemma3:12b"
+        assert settings.embedding.model_id == "nomic-embed-text"
+
+        # Verify the file was created
+        assert temp_path.exists()
+
+
+@mock.patch("src.utils.config.load_settings")
+def test_get_settings_caching(mock_load_settings):
+    """Test that get_settings caches the settings."""
+    # Create mock settings
+    mock_settings = Settings(
+        vision_llm=LLMConfig(
+            api_key="test_key",
+            api_base="http://test.com",
+            model_id="test/model"
+        ),
+        llm=LLMConfig(
+            api_key="test_key2",
+            api_base="http://test2.com",
+            model_id="test/model2"
+        ),
+        embedding=EmbeddingConfig(
+            model_id="test-model"
+        )
+    )
+    mock_load_settings.return_value = mock_settings
+
+    # Call get_settings twice
+    settings1 = get_settings()
+    settings2 = get_settings()
+
+    # Verify that load_settings was only called once
+    mock_load_settings.assert_called_once()
+
+    # Verify that the same settings object is returned
+    assert settings1 is settings2
+
+
+@mock.patch("src.utils.config.load_settings")
+def test_reload_settings(mock_load_settings):
+    """Test that reload_settings reloads the settings."""
+    # Create mock settings
+    mock_settings1 = Settings(
+        vision_llm=LLMConfig(
+            api_key="test_key",
+            api_base="http://test.com",
+            model_id="test/model"
+        ),
+        llm=LLMConfig(
+            api_key="test_key2",
+            api_base="http://test2.com",
+            model_id="test/model2"
+        ),
+        embedding=EmbeddingConfig(
+            model_id="test-model"
+        )
+    )
+    mock_settings2 = Settings(
+        vision_llm=LLMConfig(
+            api_key="test_key3",
+            api_base="http://test3.com",
+            model_id="test/model3"
+        ),
+        llm=LLMConfig(
+            api_key="test_key4",
+            api_base="http://test4.com",
+            model_id="test/model4"
+        ),
+        embedding=EmbeddingConfig(
+            model_id="test-model2"
+        )
+    )
+
+    # First call to load_settings returns mock_settings1
+    # Second call returns mock_settings2
+    mock_load_settings.side_effect = [mock_settings1, mock_settings2]
+
+    # Reset the global settings variable
+    import src.utils.config
+    src.utils.config._settings = None
+
+    # Call get_settings to initialize the cache
+    settings1 = get_settings()
+    assert settings1 == mock_settings1
+
+    # Call reload_settings to reload the settings
+    # This should set _settings to None and then call get_settings again
+    settings2 = reload_settings()
+    assert settings2 == mock_settings2
+
+    # Verify that load_settings was called twice
+    assert mock_load_settings.call_count == 2
+
+    # Verify that different settings objects are returned
+    assert settings1 is not settings2
+    assert settings1.vision_llm.api_key == "test_key"
+    assert settings2.vision_llm.api_key == "test_key3"

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.13"
 
 [[package]]
@@ -171,6 +172,8 @@ dependencies = [
     { name = "fire" },
     { name = "httpx" },
     { name = "litellm" },
+    { name = "pydantic" },
+    { name = "pytest" },
     { name = "python-dotenv" },
     { name = "smolagents" },
 ]
@@ -187,6 +190,8 @@ requires-dist = [
     { name = "fire", specifier = ">=0.7.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "litellm", specifier = ">=1.65.4.post1" },
+    { name = "pydantic", specifier = ">=2.11.3" },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "smolagents", specifier = ">=1.13.0" },
 ]


### PR DESCRIPTION
This pull request fixes #2.

The issue has been successfully resolved. The PR implements a complete configuration system that meets all the requirements specified in the issue description. Specifically:

1. The configuration is stored in `~/.clive/settings.json` as required
2. The settings structure includes all the specified options:
   - Vision LLM with api_key, api_base, and model_id in LiteLLM format
   - LLM with api_key, api_base, and model_id in LiteLLM format
   - Embedding model with model_id in Ollama's format

3. The implementation uses Pydantic models as suggested in the issue:
   - `LLMConfig` class for both LLM and Vision LLM settings
   - `EmbeddingConfig` class for embedding model settings
   - `Settings` class as the main container for all configurations

4. The PR also includes:
   - Functions to load/save settings
   - Environment variable support that takes precedence over config values
   - Default values when no config exists
   - Comprehensive test coverage
   - CLI tools for managing settings
   - Documentation explaining the configuration system

The changes integrate with the existing environment variable system in `env.py`, ensuring backward compatibility while adding the new configuration capabilities.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌